### PR TITLE
add (displayName)

### DIFF
--- a/src/components/player/atoms/settings/SourceSelectingView.tsx
+++ b/src/components/player/atoms/settings/SourceSelectingView.tsx
@@ -27,15 +27,14 @@ export function EmbedOption(props: {
   url: string;
   sourceId: string;
   routerId: string;
+  displayName?: string;
 }) {
   const { t } = useTranslation();
   const unknownEmbedName = t("player.menus.sources.unknownOption");
 
   const embedName = useMemo(() => {
-    if (!props.embedId) return unknownEmbedName;
-    const sourceMeta = getCachedMetadata().find((s) => s.id === props.embedId);
-    return sourceMeta?.name ?? unknownEmbedName;
-  }, [props.embedId, unknownEmbedName]);
+    return props.displayName || props.embedId || unknownEmbedName;
+  }, [props.displayName, props.embedId, unknownEmbedName]);
 
   const { run, errored, loading } = useEmbedScraping(
     props.routerId,
@@ -104,8 +103,7 @@ export function EmbedSelectionView({ sourceId, id }: EmbedSelectionViewProps) {
         {t("player.menus.sources.failed.text")}
       </Menu.TextDisplay>
     );
-  else if (watching)
-    content = null; // when it starts watching, empty the display
+  else if (watching) content = null;
   else if (items && sourceId)
     content = items.map((v) => (
       <EmbedOption
@@ -114,6 +112,7 @@ export function EmbedSelectionView({ sourceId, id }: EmbedSelectionViewProps) {
         url={v.url}
         routerId={id}
         sourceId={sourceId}
+        displayName={v.displayName}
       />
     ));
 


### PR DESCRIPTION
This allows providers to add optional information, such as re-naming an embed or categorizing providers by language, such as embed + language , like : mega.nz (spanish)

This pull request resolves #XXX

 - [ ] I have read and agreed to the [code of conduct](https://github.com/p-stream/p-strean/blob/production/.github/CODE_OF_CONDUCT.md).
 - [ ] I have read and complied with the [contributing guidelines](https://github.com/p-stream/p-strean/blob/production/.github/CONTRIBUTING.md).
 - [ ] I have tested all of my changes.
 - Enter discord user: `` (we require this for the contributor role)
